### PR TITLE
Add Payphone transaction card and UI components

### DIFF
--- a/app/order/page.tsx
+++ b/app/order/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 import { checkOrderPayphone } from "@/actions";
+import PayphoneCard from "@/components/shared/payphone-card";
 import { ResPayphone } from "@/interface/res-payphone";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
 const OrderDetailsPage = () => {
-  const [sale, setSale] = useState<ResPayphone | null>(null);
+  const [sale, setSale] = useState<ResPayphone[]>([]);
   const searchParams = useSearchParams();
   const clientTransactionId = searchParams.get("clientTransactionId");
 
@@ -19,10 +20,26 @@ const OrderDetailsPage = () => {
     }
   }, [clientTransactionId]);
 
+  if (!sale) {
+    return <div>Cargando detalles de la orden...</div>;
+  }
+
   return (
-    <div>
+    <main className="min-h-screen flex items-center justify-center bg-muted/10 p-4">
+      {sale.length > 0 ? (
+        <div className="w-full max-w-2xl">
+          {sale.map((transaction) => (
+            <PayphoneCard
+              key={transaction.clientTransactionId}
+              data={transaction}
+            />
+          ))}
+        </div>
+      ) : (
+        <div>No se encontraron transacciones.</div>
+      )}
       <pre>{JSON.stringify(sale, null, 2)}</pre>
-    </div>
+    </main>
   );
 };
 

--- a/components/shared/payphone-card.tsx
+++ b/components/shared/payphone-card.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { ResPayphone } from "@/interface/res-payphone";
+
+export default function PayphoneCard({ data }: { data: ResPayphone }) {
+  const {
+    amount,
+    currency,
+    cardBrand,
+    cardType,
+    lastDigits,
+    transactionStatus,
+    message,
+    clientTransactionId,
+    storeName,
+    date,
+  } = data;
+
+  return (
+    <Card className="w-full max-w-md mx-auto shadow-md border border-muted p-2 rounded-2xl">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-lg font-semibold flex justify-between items-center">
+          {storeName || "Transacción Payphone"}
+          <Badge
+            variant={
+              transactionStatus === "Approved" ? "default" : "destructive"
+            }
+          >
+            {transactionStatus}
+          </Badge>
+        </CardTitle>
+        <p className="text-sm text-muted-foreground">
+          {new Date(date).toLocaleString()}
+        </p>
+      </CardHeader>
+
+      <Separator className="my-2" />
+
+      <CardContent className="space-y-2 text-sm">
+        <div className="flex justify-between">
+          <span className="font-medium">Monto:</span>
+          <span>
+            {currency} {amount / 100}
+          </span>
+        </div>
+
+        <div className="flex justify-between">
+          <span className="font-medium">Tarjeta:</span>
+          <span>
+            {cardBrand} ({cardType}) •••• {lastDigits}
+          </span>
+        </div>
+
+        <div className="flex justify-between">
+          <span className="font-medium">ID Transacción:</span>
+          <span className="truncate max-w-[150px] text-right">
+            {clientTransactionId}
+          </span>
+        </div>
+
+        <Separator className="my-1" />
+
+        <div className="text-muted-foreground text-xs">
+          {message || "Sin mensaje de estado"}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "my-app",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -984,6 +985,52 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -1357,7 +1404,7 @@
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-brtBs0MnE9SMx7px208g39lRmC5uHZs96caOJfTjFcYSLHNamvaSMfJNagChVNkup2SdtOxKX1FDBkRSJe1ZAg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
Introduces a reusable PayphoneCard component for displaying transaction details in the order page. Adds badge and separator UI components using Radix UI, updates order page to render multiple transactions, and updates dependencies to include @radix-ui/react-separator.